### PR TITLE
Add unit tests for cn.wowspeeder.ss.SocksCommonUtils

### DIFF
--- a/src/test/java/cn/wowspeeder/ss/SocksCommonUtilsTest.java
+++ b/src/test/java/cn/wowspeeder/ss/SocksCommonUtilsTest.java
@@ -1,0 +1,61 @@
+package cn.wowspeeder.ss;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SocksCommonUtilsTest {
+
+	@Test
+	public void testIntToIp() {
+		Assert.assertEquals("11.8.0.8",
+			SocksCommonUtils.intToIp(185_073_672));
+	}
+
+	@Test
+	public void testIpv6toCompressedForm() {
+		byte[] bytes = new byte[]{
+			1, 2, 4, 8, 16, 32, 64, 127, -1, -2,
+			-4, -16, -32, -64, -128, 0};
+
+		Assert.assertEquals(
+			"102:408:1020:407f:fffe:fcf0:e0c0:8000",
+			SocksCommonUtils.ipv6toCompressedForm(bytes)
+		);
+	}
+
+	@Test
+	public void testIpv6toCompressedFormCompressionApplied() {
+		byte[] bytes = new byte[]{
+			0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 2, 4, 8, 16, 32};
+
+		Assert.assertEquals(
+			"0::2:408:1020",
+			SocksCommonUtils.ipv6toCompressedForm(bytes)
+		);
+	}
+
+	@Test
+	public void testIpv6toStr() {
+		byte[] bytes = new byte[]{
+			0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 2, 4, 8, 16, 32};
+
+		Assert.assertEquals(
+			"0:0:0:0:0:2:408:1020",
+			SocksCommonUtils.ipv6toStr(bytes));
+	}
+
+	@Test
+	public void testReadUsAscii() {
+		final ByteBuf buffer = Unpooled.copiedBuffer(
+			new byte[]{'f', 'o', 'o'});
+
+		Assert.assertEquals(
+			"foo",
+			SocksCommonUtils.readUsAscii(buffer, 3)
+		);
+	}
+}


### PR DESCRIPTION
Hi,

I've analysed your code base and noticed that `cn.wowspeeder.ss.SocksCommonUtils` in the `shadowsocks-netty` module is not fully tested.

I've written some tests that cover this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests should help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other particular classes that you consider important.